### PR TITLE
set lower minSdkVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ task clean(type: Delete) {
 
 ext {
     supportLibraryVersion = '26.0.0'
-    minSdkVersion = 21
+    minSdkVersion = 16
     targetSdkVersion = 26
     buildToolsVersion = "26.0.1"
     versionCode = 1


### PR DESCRIPTION
Got an error when i implement this lib
> Error:Execution failed for task ':app:processDebugManifest'.
> Manifest merger failed : uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [moe.feng:MaterialStepperView:0.1.1] /Users/LvWind/.gradle/caches/transforms-1/files-1.1/MaterialStepperView-0.1.1.aar/a09669f893b50fb6a1e73825f7b5f217/AndroidManifest.xml as the library might be using APIs not available in 16
  	Suggestion: use a compatible library with a minSdk of at most 16,
  		or increase this project's minSdk version to at least 21,
  		or use tools:overrideLibrary="moe.feng.common.stepperview" to force usage (may lead to runtime failures)
> 

As MaterialStepperView library did't use any API above level 21, You should set minSdkVersion lower enough.