### PR TITLE
Fix JitPack build error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-	ext.kotlin_version = '1.2.21'
+    ext.kotlin_version = '1.2.21'
     repositories {
         jcenter()
-	google()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
-	    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
 	ext.kotlin_version = '1.2.21'
     repositories {
         jcenter()
+	google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'


### PR DESCRIPTION
Fix JitPack build error Could not find com.android.tools.build:gradle:3.0.1 by adding the google() repository to buildscript.