### PR TITLE
Fixed a case in which the title was being truncated

### DIFF
--- a/library/src/main/java/moe/feng/common/stepperview/VerticalStepperItemView.java
+++ b/library/src/main/java/moe/feng/common/stepperview/VerticalStepperItemView.java
@@ -162,8 +162,12 @@ public class VerticalStepperItemView extends FrameLayout {
 			@Override
 			public void onGlobalLayout() {
 				int singleLineHeight = mTitleText.getMeasuredHeight();
-				ViewGroup.MarginLayoutParams mlp = (MarginLayoutParams) mTitleText.getLayoutParams();
-				mlp.topMargin = (mPointFrame.getMeasuredHeight() - singleLineHeight) / 2;
+				int topMargin = (mPointFrame.getMeasuredHeight() - singleLineHeight) / 2;
+				// Only update top margin when it is positive, preventing titles being truncated.
+				if (topMargin > 0) {
+					ViewGroup.MarginLayoutParams mlp = (MarginLayoutParams) mTitleText.getLayoutParams();
+					mlp.topMargin = topMargin;
+				}
 			}
 		});
 	}


### PR DESCRIPTION
While using this library, I encountered an issue in which the step titles were being truncated when using multi-line texts.
This is due to the top margin of the title getting a negative margin. Resulting in the truncated title.

The current issues did not describe this, only in issue #15 it is mentioned (which is closed).
Instead of reporting it, I have fixed it in the library itself.

It can easily be tested in the demo project. Just set the step titles to a long title resulting in a multiline title. Then going to step 2 and back to step 1, the title of the first step is truncated.
This fix just prevents the negative margin to prevent the truncated title.

For reference, check out the following screenshots when applying this fix in the demo project: (enabled showing layout-bounds)

**Earlier (with bug):**
![1-stepper-bug](https://user-images.githubusercontent.com/2484833/38468522-8eb0973a-3b47-11e8-9b95-a5a614765a46.PNG)

And when going to step 2 and back:
![1-stepper-bug2](https://user-images.githubusercontent.com/2484833/38468548-15e60dca-3b48-11e8-87c3-79ba6c2862ef.PNG)

**Now (with fix applied):**
![2-stepper-fixed](https://user-images.githubusercontent.com/2484833/38468523-945a5086-3b47-11e8-9b03-c7ac57d220ae.PNG)



